### PR TITLE
Feature/fix3

### DIFF
--- a/laravel/public/assets/css/main.css
+++ b/laravel/public/assets/css/main.css
@@ -278,6 +278,15 @@ footer {
   width: calc(100% - 3rem);
 }
 
+.expense {
+  width: 5rem;
+  float: left;
+}
+
+.expense-content {
+  width: calc(100% - 5rem);
+}
+
 .explain {
   margin-top: 2rem;
   text-align: center;
@@ -527,9 +536,17 @@ footer {
     width: 2.4rem;
   }
 
+  .expense {
+    width: 4rem;
+  }
+
   .place-content,
   .address-content {
     width: calc(100% - 2.4rem);
+  }
+
+  .expense-content {
+    width: calc(100% - 4rem);
   }
 
   .residence {

--- a/laravel/public/assets/css/main.css
+++ b/laravel/public/assets/css/main.css
@@ -498,7 +498,7 @@ footer {
   color: #696969;
 }
 
-@media (max-width: 374px) {
+@media (max-width: 340px) {
   body {
     font-size: 0.8rem !important;
   }

--- a/laravel/resources/views/commons/postContentList.blade.php
+++ b/laravel/resources/views/commons/postContentList.blade.php
@@ -24,8 +24,11 @@
 		<li>
 			場所予約：{{ $post->reservation }}
 		</li>
-		<li>
-			参加費用：{{ $post->expense }}
+		<li class="d-inline-block expense">
+			参加費用：
+		</li>
+		<li class="d-inline-block expense-content">
+			{{ $post->expense }}
 		</li>
 		<li>
 			使用球：{{ $post->ball }}


### PR DESCRIPTION
・投稿の参加費用項目について文字数が多くなり折り返した際に、項目名の下に内容が潜り込まないようにレイアウト変更

・font-size縮小の対象となるwindow幅を最大374px　→　最大340pxに変更


レビュー願います。